### PR TITLE
don't initialize _htmlWidthsAll if we are not in UTF8 mode (_htmlUTF8)

### DIFF
--- a/htmldoc/htmllib.cxx
+++ b/htmldoc/htmllib.cxx
@@ -2235,8 +2235,9 @@ htmlLoadFontWidths(void)
     {
       for (ch = 0; ch < 256; ch ++)
         _htmlWidths[i][j][ch] = 0.6f;
-      for (ch = 0; ch < 65536; ch ++)
-        _htmlWidthsAll[i][j][ch] = 0.6f;
+      if (_htmlUTF8)
+        for (ch = 0; ch < 65536; ch ++)
+          _htmlWidthsAll[i][j][ch] = 0.6f;
 
       snprintf(filename, sizeof(filename), "%s/fonts/%s.afm", _htmlData,
                _htmlFonts[i][j]);
@@ -2268,9 +2269,10 @@ htmlLoadFontWidths(void)
 	    if (_htmlGlyphs[ch] && !strcmp(_htmlGlyphs[ch], glyph))
 	      _htmlWidths[i][j][ch] = width * 0.001f;
 
-          for (ch = 0; ch < 65536; ch ++)
-            if (_htmlGlyphsAll[ch] && !strcmp(_htmlGlyphsAll[ch], glyph))
-              _htmlWidthsAll[i][j][ch] = width * 0.001f;
+          if (_htmlUTF8)
+            for (ch = 0; ch < 65536; ch ++)
+              if (_htmlGlyphsAll[ch] && !strcmp(_htmlGlyphsAll[ch], glyph))
+                _htmlWidthsAll[i][j][ch] = width * 0.001f;
 	}
 	else
 	{


### PR DESCRIPTION
This saves lots of time of computing all the widths, which are not used.