### PR TITLE
Define PNG_NO_CONFIG_H in png/Makefile.

### DIFF
--- a/png/Makefile
+++ b/png/Makefile
@@ -10,6 +10,9 @@
 
 include ../Makedefs
 
+# See PNG_NO_CONFIG_H comments in pngpriv.h
+CFLAGS += -DPNG_NO_CONFIG_H
+
 #
 # Object files...
 #


### PR DESCRIPTION
Short: tiny patch to png/Makefile to fix Centos 7 builds, which should be harmless on other builds.

Long: I'm building htmldoc for Centos 7.6.1810, and I want to use the local png instead of the system libpng. Stock gcc 4.8.5 there won't handle the `register` attribute (png/pngpriv.h:63) unless we use `-std=c99`. This patch instead tells the build to ignore the generated `../config.h`, which solves the problem without requiring c99. I don't think the `../config.h` holds anything useful for the png build anyway.
