### PR TITLE
Add desktop icons

### DIFF
--- a/desktop/Makefile
+++ b/desktop/Makefile
@@ -34,6 +34,10 @@ install:
 		$(INSTALL_DATA) htmldoc.xml $(BUILDROOT)$(datadir)/mime/packages; \
 		$(INSTALL_DIR) $(BUILDROOT)$(datadir)/pixmaps; \
 		$(INSTALL_DATA) htmldoc.xpm $(BUILDROOT)$(datadir)/pixmaps; \
+		$(INSTALL_DIR) $(BUILDROOT)$(datadir)/icons/hicolor/128x128/apps; \
+		$(INSTALL_DATA) htmldoc-128.png $(BUILDROOT)$(datadir)/icons/hicolor/128x128/apps/htmldoc.png; \
+		$(INSTALL_DIR) $(BUILDROOT)$(datadir)/icons/hicolor/256x256/apps; \
+		$(INSTALL_DATA) htmldoc-256.png $(BUILDROOT)$(datadir)/icons/hicolor/256x256/apps/htmldoc.png; \
 	fi
 
 


### PR DESCRIPTION
When packaging for Debian I added some desktop icons. It looks like AppStream prefers .png files of size 64x64 or higher.