### PR TITLE
Misc icon changes

### DIFF
--- a/desktop/Makefile
+++ b/desktop/Makefile
@@ -32,8 +32,6 @@ install:
 		$(INSTALL_DATA) htmldoc.desktop $(BUILDROOT)$(datadir)/applications; \
 		$(INSTALL_DIR) $(BUILDROOT)$(datadir)/mime/packages; \
 		$(INSTALL_DATA) htmldoc.xml $(BUILDROOT)$(datadir)/mime/packages; \
-		$(INSTALL_DIR) $(BUILDROOT)$(datadir)/pixmaps; \
-		$(INSTALL_DATA) htmldoc.xpm $(BUILDROOT)$(datadir)/pixmaps; \
 		$(INSTALL_DIR) $(BUILDROOT)$(datadir)/icons/hicolor/128x128/apps; \
 		$(INSTALL_DATA) htmldoc-128.png $(BUILDROOT)$(datadir)/icons/hicolor/128x128/apps/htmldoc.png; \
 		$(INSTALL_DIR) $(BUILDROOT)$(datadir)/icons/hicolor/256x256/apps; \

--- a/desktop/Makefile
+++ b/desktop/Makefile
@@ -32,6 +32,8 @@ install:
 		$(INSTALL_DATA) htmldoc.desktop $(BUILDROOT)$(datadir)/applications; \
 		$(INSTALL_DIR) $(BUILDROOT)$(datadir)/mime/packages; \
 		$(INSTALL_DATA) htmldoc.xml $(BUILDROOT)$(datadir)/mime/packages; \
+		$(INSTALL_DIR) $(BUILDROOT)$(datadir)/icons/hicolor/32x32/apps; \
+		$(INSTALL_DATA) htmldoc-32.png $(BUILDROOT)$(datadir)/icons/hicolor/32x32/apps/htmldoc.png; \
 		$(INSTALL_DIR) $(BUILDROOT)$(datadir)/icons/hicolor/128x128/apps; \
 		$(INSTALL_DATA) htmldoc-128.png $(BUILDROOT)$(datadir)/icons/hicolor/128x128/apps/htmldoc.png; \
 		$(INSTALL_DIR) $(BUILDROOT)$(datadir)/icons/hicolor/256x256/apps; \


### PR DESCRIPTION
- drop the XPM icon, as it is redundant with the PNG icons in the XDG hicolor icon theme
- install also the 32px PNG application icon