### PR TITLE
fix limitation for size of data:*:base64 images and max length of the html input line

### DIFF
--- a/htmldoc/file.c
+++ b/htmldoc/file.c
@@ -407,7 +407,7 @@ file_find_check(const char *filename)	/* I - File or URL */
 
     const char	*data;			/* Pointer to data */
     int		len;			/* Number of bytes */
-    char	buffer[8192];		/* Data buffer */
+    char	*buffer;		/* Data buffer */
 
     for (i = 0; i < (int)web_files; i ++)
     {
@@ -420,18 +420,22 @@ file_find_check(const char *filename)	/* I - File or URL */
 
     if ((data = strstr(filename, ";base64,")) != NULL)
     {
-      len = sizeof(buffer);
+      len = strlen(filename);
+      buffer = (char *) malloc(len);
+
       httpDecode64_2(buffer, &len, data + 8);
 
       if ((fp = file_temp(tempname, sizeof(tempname))) == NULL)
       {
 	progress_hide();
 	progress_error(HD_ERROR_WRITE_ERROR, "Unable to create temporary file \"%s\": %s", tempname, strerror(errno));
+	free(buffer);
 	return (NULL);
       }
 
       fwrite(buffer, 1, (size_t)len, fp);
       fclose(fp);
+      free(buffer);
 
       progress_hide();
 


### PR DESCRIPTION
1. currently maximum size of <img ... src='data:...:base64.....' ..> image is ~7k
2. maximum length of input line for input html document is 10240 (limited by code in htmllib.cxx)

this patch removes these limitations

test command is:

cat ./test.html | htmldoc --webpage -t pdf - > test.pdf

test.html is attached

[test.html.zip](https://github.com/michaelrsweet/htmldoc/files/7532422/test.html.zip)

