### PR TITLE
Speed up connection shutdown 

### DIFF
--- a/htmldoc/tls-gnutls.c
+++ b/htmldoc/tls-gnutls.c
@@ -1282,7 +1282,7 @@ _httpTLSStop(http_t *http)		/* I - Connection to server */
   int	error;				/* Error code */
 
 
-  error = gnutls_bye(http->tls, http->mode == _HTTP_MODE_CLIENT ? GNUTLS_SHUT_RDWR : GNUTLS_SHUT_WR);
+  error = gnutls_bye(http->tls, GNUTLS_SHUT_WR);
   if (error != GNUTLS_E_SUCCESS)
     _cupsSetError(IPP_STATUS_ERROR_INTERNAL, gnutls_strerror(errno), 0);
 


### PR DESCRIPTION
We have an issue where producing PDFs with remote images experiences 10s delay when trying to close the connection. 

To my understanding, always using `_WR` should be good enough for our purposes - it tells remote we are done but doesn't needlessly wait for the remote to acknowledge it.