### PR TITLE
htmldoc.desktop: drop deprecated category

### DIFF
--- a/desktop/htmldoc.desktop
+++ b/desktop/htmldoc.desktop
@@ -6,5 +6,5 @@ TryExec=htmldoc
 Exec=htmldoc %F
 Icon=htmldoc
 Terminal=false
-Categories=Application;Office;X-Red-Hat-Base;
+Categories=Office;X-Red-Hat-Base;
 Keywords=HTML;PDF;EPUB;Converter


### PR DESCRIPTION
Without these, desktop-file-validate complains:

/usr/share/applications/htmldoc.desktop: warning: value "Application;Office;X-Red-Hat-Base;" for key "Categories" in group "Desktop Entry" contains a deprecated value "Application"

"Application" is no longer a valid category according to the spec:

https://specifications.freedesktop.org/menu-spec/menu-spec-1.0.html#category-registry

Signed-off-by: John Helmert III <ajak@gentoo.org>