### PR TITLE
add file:// method

### DIFF
--- a/htmldoc/file.c
+++ b/htmldoc/file.c
@@ -934,6 +934,8 @@ file_method(const char *s)	/* I - Filename or URL */
     return ("ftp");
   else if (strncmp(s, "mailto:", 7) == 0)
     return ("mailto");
+  else if (strncmp(s, "file:", 5) == 0)
+    return ("file");
   else
     return (NULL);
 }


### PR DESCRIPTION
Issue https://github.com/michaelrsweet/htmldoc/issues/508 reports that href `file://...` is mapped to `http://remote.../file://...`, which will never open in modern browsers capable of opening the "file://" method.

This is a proposed fix for #508.

The screenshot illustrates the use case. After converting an online HTML document to PDF (using the command shown in #507), open the output file in a PDF viewer, scroll down to the link in the screenshot, and click the link. Without this commit the PDF viewer, then the browser, open `http://remote.../file://...`, and fail. With this commit the "file://" method is preserved, so the browser can successfully open a local file.

![screenshot](https://github.com/michaelrsweet/htmldoc/assets/1414102/814f30a0-f417-46eb-8390-a94542162050)