### PR TITLE
Fix a segfault I found in htmldoc

### DIFF
--- a/htmldoc/markdown.cxx
+++ b/htmldoc/markdown.cxx
@@ -385,7 +385,7 @@ get_text(uchar *text)                   /* I - Markdown text */
   static uchar  buffer[8192];           /* Temporary buffer */
 
 
-  if (!_htmlUTF8)
+  if (!_htmlUTF8 || text == NULL)
     return (text);
 
   bufptr = buffer;


### PR DESCRIPTION
This patch/merge request/pull request fixes a segfault I found in htmldoc.

In more detail, let’s take the following file:

https://github.com/samboy/blog/blob/main/markdown/htmldoc-segfault.md

And let’s run that file like this in htmldoc:

```
htmldoc --charset utf-8 htmldoc-segfault.md
```

The expected results is that we will get some HTML outputted on the standard output.

The actual result is that htmldoc segfaults.

The bug is triggered because there are two spaces after the italic text at the end of the line.

This patch fixes the bug.

This has only been applied to and tested with htmldoc 1.9.16, the final version of htmldoc which (easily) compiles in Cygwin (see https://github.com/michaelrsweet/htmldoc/issues/547 for discussion about that issue).