### PR TITLE
Fix unconditional cups/http.h include when building with --without-http

### DIFF
--- a/htmldoc/htmldoc.cxx
+++ b/htmldoc/htmldoc.cxx
@@ -15,7 +15,9 @@
 #define _HTMLDOC_CXX_
 #include "htmldoc.h"
 #include "markdown.h"
-#include <cups/http.h>
+#ifdef HAVE_LIBCUPS
+#  include <cups/http.h>
+#endif // HAVE_LIBCUPS
 #include <ctype.h>
 #include <fcntl.h>
 


### PR DESCRIPTION
Closes #565

## Problem

Building with `--without-http` fails with:

```
htmldoc.cxx:18:10: fatal error: cups/http.h: No such file or directory
   18 | #include <cups/http.h>
compilation terminated.
```

The include on line 18 of `htmldoc.cxx` is unconditional, requiring `libcups-dev` even when the `--without-http` flag is passed.

## Fix

Wrap the include with a `HAVE_LIBCUPS` preprocessor guard, consistent with how `htmllib.cxx` already handles it:

```c
#ifdef HAVE_LIBCUPS
#  include <cups/http.h>
#endif // HAVE_LIBCUPS
```